### PR TITLE
Fix menu item counter

### DIFF
--- a/tpl/navigation.html.twig
+++ b/tpl/navigation.html.twig
@@ -35,9 +35,9 @@
         <td class="main">
             {% include "include/navigation_shopselect.html.twig" %}
             {% block admin_navigation_menustructure %}
+                {% set menuIndex = 0 %}
                 {% for menuholder in menustructure %}
                     {% if menuholder.nodeType == constant("XML_ELEMENT_NODE") and menuholder.childNodes.length %}
-                        {% set menuIndex = 0 %}
                         <h2>
                             {% if menuholder.getAttribute('url') %}
                             <a href="{{ oViewConf.getSelfLink()|raw }}&cl=navigation&amp;fnc=exturl&amp;url={{ menuholder.getAttribute('url')|escape('url') }}"


### PR DESCRIPTION
Project-related menu items in the admin were created with incorrect class names because the menu index was reset to 0 within the loop.
