### PR TITLE
Fix wrong product picture counter

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fixed menu item counter for vendor-specific menu sections [PR-10](https://github.com/OXID-eSales/twig-admin-theme/pull/10)
+- Fixed wrong product picture counter showing 13 instead of 12 [PR-14](https://github.com/OXID-eSales/twig-admin-theme/pull/14)
 
 ## v3.0.1 - 2025-11-10
 

--- a/tpl/article_pictures.html.twig
+++ b/tpl/article_pictures.html.twig
@@ -101,7 +101,7 @@ function editThis(sID)
                   </tr>
                  {% endif %}
 
-                  {% for picRow in 1..iPicCount+1 %}
+                  {% for picRow in 1..iPicCount %}
                   {% set iIndex = loop.index %}
 
                   <tr>


### PR DESCRIPTION
product picture counter use wrong numbers in the picRow loop and insteat of 12 pictures it will count and show 13 pictures